### PR TITLE
[FEAT] 업체 생성 기능 구현

### DIFF
--- a/common/src/main/java/com/fastline/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/fastline/common/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
 	LOGOUT_FAIL(HttpStatus.UNAUTHORIZED, "로그아웃 실패"),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 조회 실패"),
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호 변경 실패"),
-	ALREADY_DELETED_USER(HttpStatus.CONFLICT, "회원 삭제 실패");
+	ALREADY_DELETED_USER(HttpStatus.CONFLICT, "회원 삭제 실패"),
+
+    // 업체 (vendor)
+    ADDRESS_DUPLICATED(HttpStatus.CONFLICT, "업체 등록 실패");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/common/src/main/java/com/fastline/common/success/SuccessCode.java
+++ b/common/src/main/java/com/fastline/common/success/SuccessCode.java
@@ -15,8 +15,10 @@ public enum SuccessCode {
 	USER_READ_SUCCESS(HttpStatus.OK, "회원 정보 조회 성공"),
 	USER_UPDATE_SUCCESS(HttpStatus.OK, "회원 정보 수정 성공"),
 	PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, "비밀번호 수정 성공"),
-	USER_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "회원 삭제 성공");
+	USER_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "회원 삭제 성공"),
 
+    // 업체 (vendor)
+    VENDOR_SAVE_SUCCESS(HttpStatus.CREATED, "업체 등록 성공");
 	private final HttpStatus httpStatus;
 	private final String message;
 }

--- a/vendor-service/build.gradle
+++ b/vendor-service/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.7'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
 }
 
 group = 'com.fastline'
@@ -19,7 +19,15 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/vendor-service/src/main/java/com/fastline/vendorservice/VendorDummyDataInit.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/VendorDummyDataInit.java
@@ -1,0 +1,31 @@
+package com.fastline.vendorservice;
+
+import com.fastline.vendorservice.domain.entity.Vendor;
+import com.fastline.vendorservice.domain.entity.VendorType;
+import com.fastline.vendorservice.domain.repository.VendorRepository;
+import com.fastline.vendorservice.domain.vo.VendorAddress;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class VendorDummyDataInit implements ApplicationRunner {
+
+    private final VendorRepository vendorRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        vendorRepository.insert(
+                Vendor.create(
+                        "testVendor",
+                        VendorType.PRODUCER,
+                        VendorAddress.create("경기도","분당구","정자동", "12385"),
+                        UUID.randomUUID()
+                        )
+        );
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/VendorServiceApplication.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/VendorServiceApplication.java
@@ -2,8 +2,10 @@ package com.fastline.vendorservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.fastline")
+@EnableJpaAuditing
 public class VendorServiceApplication {
 
     public static void main(String[] args) {

--- a/vendor-service/src/main/java/com/fastline/vendorservice/application/VendorService.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/application/VendorService.java
@@ -1,0 +1,53 @@
+package com.fastline.vendorservice.application;
+
+import com.fastline.vendorservice.application.command.CreateVendorCommand;
+import com.fastline.vendorservice.domain.entity.Vendor;
+import com.fastline.vendorservice.domain.entity.VendorType;
+import com.fastline.vendorservice.domain.repository.VendorRepository;
+import com.fastline.vendorservice.domain.vo.VendorAddress;
+import com.fastline.vendorservice.infrastructure.external.HubClient;
+import com.fastline.vendorservice.presentation.response.VendorResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VendorService {
+
+    private final VendorRepository repository;
+//    private final HubClient hubClient; -- 허브 서비스로 API 호출을 보낼 책임을 갖음
+
+    /**
+     * TODO: 허브 서비스로의 API 호출 성공, 실패시 흐름처리 작성 필요
+     * TODO: 성공시, Vendor.create의 UUID.randomUUID() 부분에 허브ID. 실패시 적절한 예외처리
+     */
+    @Transactional
+    public VendorResponse insert(CreateVendorCommand createCommand) {
+
+        VendorType vendorType = VendorType.fromString(createCommand.type());
+
+        VendorAddress vendorAddress = VendorAddress.create(
+                createCommand.city(),
+                createCommand.district(),
+                createCommand.roadName(),
+                createCommand.zipCode());
+
+//        hubClient.findHub(); -- 존재하는 허브인지 허브 서비스로 API 호출. 없거나 에러시 적절한 처리 필요
+
+        Vendor vendor = Vendor.create(
+                createCommand.name(), vendorType, vendorAddress, UUID.randomUUID()
+        );
+
+        Vendor insertedVendor = repository.insert(vendor);
+        return new VendorResponse(
+                insertedVendor.getId(),
+                insertedVendor.getName(),
+                insertedVendor.getType(),
+                insertedVendor.getAddress(),
+                insertedVendor.getHubId()
+        );
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/application/command/CreateVendorCommand.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/application/command/CreateVendorCommand.java
@@ -1,0 +1,14 @@
+package com.fastline.vendorservice.application.command;
+
+import java.util.UUID;
+
+public record CreateVendorCommand(
+        String name,
+        String type,
+        String city,
+        String district,
+        String roadName,
+        String zipCode,
+        UUID hubId
+) {
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/domain/entity/Vendor.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/domain/entity/Vendor.java
@@ -1,0 +1,48 @@
+package com.fastline.vendorservice.domain.entity;
+
+import com.fastline.common.exception.CustomException;
+import com.fastline.common.exception.ErrorCode;
+import com.fastline.common.jpa.TimeBaseEntity;
+import com.fastline.vendorservice.domain.vo.VendorAddress;
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.Getter;
+
+@Entity
+@Table(name = "p_vendor", uniqueConstraints = @UniqueConstraint(name = "addressIsUnique", columnNames = {"city", "district", "roadName", "zipCode"}))
+@Getter
+public class Vendor extends TimeBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "vendor_id")
+	private UUID id;
+
+	@Column(nullable = false, length = 30)
+	private String name;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
+	private VendorType type;
+
+    @Embedded
+	@Column(nullable = false, unique = true)
+	private VendorAddress address;
+
+    @Column(nullable = false)
+	private UUID hubId;
+
+	protected Vendor() {}
+
+    public static Vendor create(String name, VendorType type, VendorAddress address, UUID hubId) {
+        if(name == null || type == null || address == null || hubId == null)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        Vendor vendor = new Vendor();
+        vendor.name = name;
+        vendor.type = type;
+        vendor.address = address;
+        vendor.hubId = hubId;
+        return vendor;
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/domain/entity/VendorType.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/domain/entity/VendorType.java
@@ -1,0 +1,22 @@
+package com.fastline.vendorservice.domain.entity;
+
+import com.fastline.common.exception.CustomException;
+import com.fastline.common.exception.ErrorCode;
+
+public enum VendorType {
+	PRODUCER,
+	CONSUMER;
+
+    public static VendorType fromString(String value) {
+        if(value == null)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        VendorType vendorType;
+        try {
+            vendorType = VendorType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        }
+        return vendorType;
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/domain/repository/VendorRepository.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/domain/repository/VendorRepository.java
@@ -1,0 +1,10 @@
+package com.fastline.vendorservice.domain.repository;
+
+import com.fastline.vendorservice.domain.entity.Vendor;
+
+import java.util.UUID;
+
+public interface VendorRepository {
+
+    Vendor insert(Vendor vendor);
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/domain/vo/VendorAddress.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/domain/vo/VendorAddress.java
@@ -1,0 +1,41 @@
+package com.fastline.vendorservice.domain.vo;
+
+import com.fastline.common.exception.CustomException;
+import com.fastline.common.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VendorAddress {
+
+    @Column(length = 30, nullable = false)
+    private String city;
+
+    @Column(length = 30, nullable = false)
+    private String district;
+
+    @Column(length = 30, nullable = false)
+    private String roadName;
+
+    @Column(length = 10, nullable = false)
+    private String zipCode;
+
+    public static VendorAddress create(String city, String district, String roadName, String zipCode) {
+        if(city == null || district == null || roadName == null || zipCode == null)
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+        VendorAddress vendorAddress = new VendorAddress();
+        vendorAddress.city = city;
+        vendorAddress.district = district;
+        vendorAddress.roadName = roadName;
+        vendorAddress.zipCode = zipCode;
+        return vendorAddress;
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/external/HubClient.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/external/HubClient.java
@@ -1,0 +1,4 @@
+package com.fastline.vendorservice.infrastructure.external;
+
+public interface HubClient {
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/repository/JpaVendorRepository.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/repository/JpaVendorRepository.java
@@ -1,0 +1,9 @@
+package com.fastline.vendorservice.infrastructure.repository;
+
+import com.fastline.vendorservice.domain.entity.Vendor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaVendorRepository extends JpaRepository<Vendor, UUID> {
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/repository/VendorRepositoryAdapter.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/infrastructure/repository/VendorRepositoryAdapter.java
@@ -1,0 +1,32 @@
+package com.fastline.vendorservice.infrastructure.repository;
+
+import com.fastline.common.exception.CustomException;
+import com.fastline.common.exception.ErrorCode;
+import com.fastline.vendorservice.domain.entity.Vendor;
+import com.fastline.vendorservice.domain.repository.VendorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class VendorRepositoryAdapter implements VendorRepository{
+
+    private final JpaVendorRepository jpaVendorRepository;
+
+    @Override
+    public Vendor insert(Vendor vendor) {
+
+        Vendor insertedVendor = jpaVendorRepository.save(vendor);
+
+        try{
+            jpaVendorRepository.flush();
+        } catch (DataIntegrityViolationException de){
+            throw new CustomException(ErrorCode.ADDRESS_DUPLICATED);
+        }
+
+        return insertedVendor;
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/presentation/controller/VendorController.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/presentation/controller/VendorController.java
@@ -1,0 +1,41 @@
+package com.fastline.vendorservice.presentation.controller;
+
+import com.fastline.common.response.ApiResponse;
+import com.fastline.common.response.ResponseUtil;
+import com.fastline.common.success.SuccessCode;
+import com.fastline.vendorservice.application.VendorService;
+import com.fastline.vendorservice.application.command.CreateVendorCommand;
+import com.fastline.vendorservice.presentation.request.VendorCreateRequest;
+import com.fastline.vendorservice.presentation.response.VendorResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/vendor")
+@RequiredArgsConstructor
+public class VendorController {
+
+    private final VendorService service;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<VendorResponse>> insertVendor(@RequestBody @Valid VendorCreateRequest createRequest) {
+
+        CreateVendorCommand createCommand = new CreateVendorCommand(
+                createRequest.name(),
+                createRequest.type(),
+                createRequest.city(),
+                createRequest.district(),
+                createRequest.roadName(),
+                createRequest.zipCode(),
+                createRequest.hubId()
+        );
+
+        VendorResponse response = service.insert(createCommand);
+        return ResponseUtil.successResponse(SuccessCode.VENDOR_SAVE_SUCCESS , response);
+    }
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/presentation/request/VendorCreateRequest.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/presentation/request/VendorCreateRequest.java
@@ -1,0 +1,38 @@
+package com.fastline.vendorservice.presentation.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record VendorCreateRequest(
+
+        @NotEmpty(message = "업체 이름은 필수항목 입니다")
+        @Size(max = 30)
+        String name,
+
+        @NotEmpty(message = "업체 종류는 필수항목 입니다")
+        String type,
+
+        @NotEmpty(message = "주소는 필수항목 입니다")
+        @Size(max = 30)
+        String city,
+
+        @NotEmpty(message = "주소는 필수항목 입니다")
+        @Size(max = 30)
+        String district,
+
+        @NotEmpty(message = "주소는 필수항목 입니다")
+        @Size(max = 30)
+        String roadName,
+
+        @NotEmpty(message = "주소는 필수항목 입니다")
+        @Pattern(regexp = "^\\d{5}$", message = "우편번호는 5자리의 숫자로만 이루어져야 합니다")
+        String zipCode,
+
+        @NotNull(message = "허브의 아이디는 필수항목 입니다")
+        UUID hubId
+) {
+}

--- a/vendor-service/src/main/java/com/fastline/vendorservice/presentation/response/VendorResponse.java
+++ b/vendor-service/src/main/java/com/fastline/vendorservice/presentation/response/VendorResponse.java
@@ -1,0 +1,15 @@
+package com.fastline.vendorservice.presentation.response;
+
+import com.fastline.vendorservice.domain.entity.VendorType;
+import com.fastline.vendorservice.domain.vo.VendorAddress;
+
+import java.util.UUID;
+
+public record VendorResponse(
+        UUID vendorId,
+        String vendorName,
+        VendorType vendorType,
+        VendorAddress address,
+        UUID hubId
+) {
+}

--- a/vendor-service/src/main/resources/application.properties
+++ b/vendor-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=vendor-service

--- a/vendor-service/src/main/resources/application.yml
+++ b/vendor-service/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: vendor-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: 1234
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
🌟개요
---
업체 생성 기능 구현입니다

🌐연결된 Issues
---
Closes #15 

📋작업사항
---
흐름은 다음과 같습니다.

1. VendorController.insertVendor() 로 요청을 받습니다. Request객체를 Command객체로 변환하여 Service에 넘깁니다.

2. Service에서 Vendor 엔티티에 필요한 값들을 생성합니다. 생성은 각 클래스 본인들이 책임집니다.
  2.1: Service에 있는 hubClient는 Command객체 안의 hubId로 허브가 존재하는지 허브 서비스로 API요청을 보내는 역할입니다.
      -> 지금은 실제 요청을 보내지 않고, 임시로 랜덤한 UUID를 생성해 저장합니다. 허브 서비스가 합쳐지면 수정하겠습니다.
  2.2: 문제가 없다면, Repository로 생성된 Vendor를 넘깁니다.

3. Repository에서 DB에 저장 요청을 보냅니다.
  3.1: try-catch를 사용했는데, Vendor클래스에 VendorAddress로 유니크 제약조건을 걸었습니다. 
        이 제약조건은 DB에 위임하는 식으로 작성했기 때문에 실제로 쿼리를 보내야 해서 flush()를 호출해 예외를 잡습니다.

✏️작성한 이슈 외 작업사항
---
1. Common 모듈의 SuccessCode, ErrorCode에 필요한 값들을 추가했습니다.
2. 해당 모듈의 시작 클래스에 @EnableJpaAuditing, @SpringBootApplication(scanBasePackages = "com.fastline") 추가했습니다.
3. 시작 클래스와 같은 위치에, 테스트용 더미 데이터를 넣는 클래스를 추가했습니다.

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
