### PR TITLE
[FEAT] 배송 경로 기록 삭제

### DIFF
--- a/common/src/main/java/com/fastline/common/success/SuccessCode.java
+++ b/common/src/main/java/com/fastline/common/success/SuccessCode.java
@@ -18,7 +18,7 @@ public enum SuccessCode {
 	PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, "비밀번호 수정 성공"),
 	USER_WITHDRAWAL_REQUEST_SUCCESS(HttpStatus.OK, "회원탈퇴 신청 성공"),
 	USER_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "회원 삭제 성공"),
-	//배달 매니저(delivery manager)
+	// 배달 매니저(delivery manager)
 	DELIVERY_MANAGER_CREATE_SUCCESS(HttpStatus.CREATED, "배달 매니저 생성 성공"),
 	DELIVERY_MANAGER_READ_SUCCESS(HttpStatus.OK, "배달 매니저 조회 성공"),
 	DELIVERY_MANAGER_UPDATE_SUCCESS(HttpStatus.CREATED, "배달 매니저 수정 성공"),
@@ -45,7 +45,8 @@ public enum SuccessCode {
 	DELIVERY_SAVE_SUCCESS(HttpStatus.CREATED, "배송 생성 성공"),
 	DELIVERY_FIND_SUCCESS(HttpStatus.OK, "배송 조회 성공"),
 	DELIVERY_UPDATE_SUCCESS(HttpStatus.OK, "배송 수정 성공"),
-	DELIVERY_DELETE_SUCCESS(HttpStatus.OK, "배송 삭제 성공");
+	DELIVERY_DELETE_SUCCESS(HttpStatus.OK, "배송 삭제 성공"),
+	DELIVERY_PATH_DELETE_SUCCESS(HttpStatus.OK, "배송 경로 기록 삭제 성공");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/delivery-service/src/main/java/com/fastline/deliveryservice/application/DeliveryService.java
+++ b/delivery-service/src/main/java/com/fastline/deliveryservice/application/DeliveryService.java
@@ -118,4 +118,18 @@ public class DeliveryService {
 
 		log.info("배송 정보 삭제 완료: deliveryId={}", deliveryId);
 	}
+
+	@Transactional
+	public void deletePath(UUID deliveryId, UUID pathId, Long userId) {
+		log.info("배송 경로 기록 삭제 시작: deliveryId={}, pathId={}", deliveryId, pathId);
+
+		Delivery delivery =
+				deliveryRepository
+						.findById(deliveryId)
+						.orElseThrow(() -> new IllegalArgumentException("배송을 찾을 수 없습니다."));
+
+		delivery.deletePath(pathId, userId);
+
+		log.info("배송 경로 기록 삭제 완료: deliveryId={}, pathId={}", deliveryId, pathId);
+	}
 }

--- a/delivery-service/src/main/java/com/fastline/deliveryservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/fastline/deliveryservice/domain/entity/Delivery.java
@@ -177,4 +177,14 @@ public class Delivery extends TimeBaseEntity {
 			path.delete(userId);
 		}
 	}
+
+	public void deletePath(UUID pathId, Long userId) {
+		DeliveryPath targetPath =
+				this.paths.stream()
+						.filter(p -> p.getDeliveryPathId().equals(pathId))
+						.findFirst()
+						.orElseThrow(() -> new IllegalArgumentException("해당 시퀀스의 배송 경로를 찾을 수 없습니다: " + pathId));
+
+		targetPath.delete(userId);
+	}
 }

--- a/delivery-service/src/main/java/com/fastline/deliveryservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/fastline/deliveryservice/presentation/DeliveryController.java
@@ -124,4 +124,18 @@ public class DeliveryController {
 		log.info("배송 삭제 성공: deliveryId={}", deliveryId);
 		return ResponseUtil.successResponse(SuccessCode.DELIVERY_DELETE_SUCCESS);
 	}
+
+	/* 배송 경로 기록 삭제 */
+	@DeleteMapping("/{deliveryId}/paths/{pathId}")
+	public ResponseEntity<ApiResponse<Void>> deleteDeliveryPath(
+			@PathVariable UUID deliveryId, @PathVariable UUID pathId) {
+		log.info("배송 경로 기록 삭제 요청: deliveryId={}, pathId={}", deliveryId, pathId);
+
+		Long userId = 1234L; // 추후 인증 연동 예정
+
+		deliveryService.deletePath(deliveryId, pathId, userId);
+
+		log.info("배송 경로 기록 삭제 성공: deliveryId={}, pathId={}", deliveryId, pathId);
+		return ResponseUtil.successResponse(SuccessCode.DELIVERY_PATH_DELETE_SUCCESS);
+	}
 }


### PR DESCRIPTION
🌟개요
---

배송 경로 기록 삭제

🌐연결된 Issues
---
Closes #60 

📋작업사항
---

 배송 경로 기록 삭제
- 배송(delivery)이 aggregate root고 배송 경로 기록(delivery path)가 내부 엔티티이므로 외부에서 직접 접근 불가
- 따라서 배송 엔티티 내부에서 접근하여 처리한다.

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
