### PR TITLE
[FEAT] FeignClient 사용시, 헤더에 jwt 토큰을 같이보내는 설정작업

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     //spring security
     api "org.springframework.boot:spring-boot-starter-security"
 
+    //feignclient
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     // bcrypt
     api 'at.favre.lib:bcrypt:0.10.2'
 

--- a/common/src/main/java/com/fastline/common/security/feignclient/FeignClientConfig.java
+++ b/common/src/main/java/com/fastline/common/security/feignclient/FeignClientConfig.java
@@ -1,0 +1,24 @@
+package com.fastline.common.security.feignclient;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignClientConfig implements RequestInterceptor {
+
+	@Override
+	public void apply(RequestTemplate requestTemplate) {
+
+		ServletRequestAttributes attributes =
+				(ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+		HttpServletRequest request = attributes.getRequest();
+		String token = request.getHeader("Authorization");
+
+		requestTemplate.header("Authorization", token);
+	}
+}


### PR DESCRIPTION
🌟개요
---
FeignClient 사용시, 헤더에 jwt 토큰을 같이보내는 설정작업

🌐연결된 Issues
---
Closes #115 

📋작업사항
---
common 모듈에 openfeign 의존성 주입,
common 모듈하위 패키지 security.feignclient 생성 후 패키지 안에 config파일 추가

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
